### PR TITLE
Refactor/Transactions

### DIFF
--- a/prisma/migrations/20230116032827_add_preview_feature_and_remove_duration_from_activity_table/migration.sql
+++ b/prisma/migrations/20230116032827_add_preview_feature_and_remove_duration_from_activity_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `duration` on the `Activity` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Activity" DROP COLUMN "duration";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["interactiveTransactions"]
 }
 
 datasource db {
@@ -151,7 +152,6 @@ model Activity {
   name            String
   startsAt        DateTime
   endsAt          DateTime  
-  duration        Int
   capacity        Int
   ActivityBooking ActivityBooking[]
   createdAt       DateTime          @default(now())

--- a/src/repositories/activities-repository/index.ts
+++ b/src/repositories/activities-repository/index.ts
@@ -31,7 +31,9 @@ async function findActivitiesWithLocals(date: Date) {
           startsAt: true,
           endsAt: true,
           capacity: true,
-          ActivityBooking: true,          
+          _count: {
+            select: { ActivityBooking: true },
+          },
         }
       },
     },

--- a/src/repositories/payment-repository/index.ts
+++ b/src/repositories/payment-repository/index.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/config";
 import { Payment } from "@prisma/client";
+import { TicketStatus } from "@prisma/client";
 
 async function findPaymentByTicketId(ticketId: number) {
   return prisma.payment.findFirst({
@@ -18,11 +19,31 @@ async function createPayment(ticketId: number, params: PaymentParams) {
   });
 }
 
+async function createAndProcessPayment(ticketId: number, params: PaymentParams) {
+  const createPayment = prisma.payment.create({
+    data: {
+      ticketId,
+      ...params,
+    }
+  });
+  const processPayment = prisma.ticket.update({
+    where: {
+      id: ticketId,
+    },
+    data: {
+      status: TicketStatus.PAID,
+    }
+  });
+
+  return prisma.$transaction([createPayment, processPayment]);
+}
+
 export type PaymentParams = Omit<Payment, "id" | "createdAt" | "updatedAt">
 
 const paymentRepository = {
   findPaymentByTicketId,
   createPayment,
+  createAndProcessPayment,
 };
 
 export default paymentRepository;

--- a/src/services/activities-service/index.ts
+++ b/src/services/activities-service/index.ts
@@ -11,12 +11,12 @@ async function getActivities(userId: number, activityDate: string | undefined): 
   await checkTicketIsRemote(userId);
 
   if (activityDate) {    
-    const timeStamp = Date.parse(activityDate);
+    const timeStamp: number | string = Date.parse(activityDate);
     if (isNaN(timeStamp)) {
       throw invalidDataError(["Date cannot be read"]);
     }
 
-    const date = new Date(timeStamp);
+    const date: Date = new Date(timeStamp);
     return activitiesRepository.findActivitiesWithLocals(date);
   }
 
@@ -72,6 +72,8 @@ export type LocalsActivities = (Local & {
       startsAt: Date;
       endsAt: Date;
       capacity: number;
-      ActivityBooking: ActivityBooking[];
+      _count: {
+        ActivityBooking: number;
+      }
   }[];
 });

--- a/src/services/enrollments-service/index.ts
+++ b/src/services/enrollments-service/index.ts
@@ -67,9 +67,7 @@ async function createOrUpdateEnrollmentWithAddress(params: CreateOrUpdateEnrollm
     throw notFoundError();
   }
 
-  const newEnrollment = await enrollmentRepository.upsert(params.userId, enrollment, exclude(enrollment, "userId"));
-
-  await addressRepository.upsert(newEnrollment.id, address, address);
+  await enrollmentRepository.upsertEnrollmentAndAddress(params.userId, enrollment, exclude(enrollment, "userId"), address, address);
 }
 
 function getAddressForUpsert(address: CreateAddressParams) {

--- a/src/services/payments-service/index.ts
+++ b/src/services/payments-service/index.ts
@@ -39,9 +39,7 @@ async function paymentProcess(ticketId: number, userId: number, cardData: CardPa
     cardLastDigits: cardData.number.toString().slice(-4),
   };
 
-  const payment = await paymentRepository.createPayment(ticketId, paymentData);
-
-  await ticketRepository.ticketProcessPayment(ticketId);
+  const [payment] = await paymentRepository.createAndProcessPayment(ticketId, paymentData);
 
   return payment;
 }


### PR DESCRIPTION
- Refatoração de algumas querys no prisma para funcionarem como transactions.
   - Foi necessário fazer uma nova migration para não ter problemas com a tipagem do typescript 
- Adição do count para o `ActivityBooking` no retorno da query `findActivitiesWithLocals`
- Remoção do campo `duration` para a tabela `Activity`